### PR TITLE
Repos previously under RagtagTeam now listed under RagtagOpen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Documentation for the cta-aggregator project
 This repo uses [slate](https://github.com/lord/slate) to allow markdown-driven 
 documentation.  
 
-The codebase for the CTA Aggregator is located here: https://github.com/Ragtagteam/cta-aggregator.
+The codebase for the CTA Aggregator is located here: https://github.com/RagtagOpen/cta-aggregator.
 
-This docs site is deployed at https://ragtagteam.github.io/cta-aggregator-docs/.
+This docs site is deployed at https://ragtagopen.github.io/cta-aggregator-docs/.
 
 ## Setup
 
@@ -24,7 +24,7 @@ pull the changes down to your local master branch and then run the deploy script
 
 * In your terminal, get on your master branch and make sure it's up to date with the remote.
 * Run `bash deploy.sh`.
-* In your browser, navigate [here](https://ragtagteam.github.io/cta-aggregator-docs) and verify that everyhing looks correct.
+* In your browser, navigate [here](https://ragtagopen.github.io/cta-aggregator-docs) and verify that everyhing looks correct.
 
 
 ## To Do

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -40,7 +40,7 @@ phone call.
 
 The API presents data in JSON.  You can write consumers or scrapers in any language you want.
 If you're working in Ruby, then you may want to leverage the Ruby gem,
-located here: [https://github.com/Ragtagteam/cta-aggregator-client-ruby](https://github.com/Ragtagteam/cta-aggregator-client-ruby/).
+located here: [https://github.com/RagtagOpen/cta-aggregator-client-ruby](https://github.com/RagtagOpen/cta-aggregator-client-ruby/).
 This gem provides simple interface for reading and writing data from the API. It's especially
 helpful for creating resoucres, since you can just pass it Ruby hashes and the gem will take care
 of constructing the JSON payload.


### PR DESCRIPTION
This PR updates the documentation site so that we list all repos as being under the "RagtagOpen" github profile.  Previously, some repos were available on the RagtagTeam profile.