### PR TITLE
All examples not refer to resistr.tech (rather than localhost)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,5 @@ pull the changes down to your local master branch and then run the deploy script
 
 
 ## To Do
-* Swap out references to `localhost:3000` with references to prod host name
 * Show examples of what happens when user attempts to create duplicate record
 * Show examples of what happens when user attempts to provide malformed request

--- a/source/includes/_advocacy_campaigns.md
+++ b/source/includes/_advocacy_campaigns.md
@@ -21,7 +21,7 @@ For more information on OSDI's Advocacy Campaign resource, follow this link: [ht
 ## Get All Advocacy Campaigns
 
 ```shell
-curl -X GET "http://localhost:3000/v1/advocacy_campaigns"
+curl -X GET "https://www.resistr.tech/v1/advocacy_campaigns"
   -H "Accept: application/vnd.api+json"
   -H "Content-Type: application/vnd.api+json"
 ```
@@ -43,7 +43,7 @@ JSON.parse(response.body)
             "id": "3c29ff31-d859-42fd-a786-c69306eadb86",
             "type": "advocacy_campaigns",
             "links": {
-                "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86"
+                "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86"
             },
             "attributes": {
                 "title": "Express Outrage at Open White Supremacy Rally in Charlottesville",
@@ -62,20 +62,20 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/user",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/user"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/user",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/user"
                     }
                 },
                 "targets": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/targets",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/targets"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/targets",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/targets"
                     }
                 },
                 "target_list": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/target_list",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/target_list"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/target_list",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/target_list"
                     }
                 }
             }
@@ -84,7 +84,7 @@ JSON.parse(response.body)
             "id": "8cd8e9ac-f684-4cdf-8e67-60c40e386eff",
             "type": "advocacy_campaigns",
             "links": {
-                "self": "http://localhost:3000/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff"
+                "self": "https://www.resistr.tech/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff"
             },
             "attributes": {
                 "title": " Demand the Removal of Bannon, Gorka, and Miller from the White House",
@@ -103,20 +103,20 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/relationships/user",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/user"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/relationships/user",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/user"
                     }
                 },
                 "targets": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/relationships/targets",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/targets"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/relationships/targets",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/targets"
                     }
                 },
                 "target_list": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/relationships/target_list",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/target_list"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/relationships/target_list",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/8cd8e9ac-f684-4cdf-8e67-60c40e386eff/target_list"
                     }
                 }
             }
@@ -125,7 +125,7 @@ JSON.parse(response.body)
             "id": "e895f3c4-d4f4-47fe-aeaa-1f4745287d04",
             "type": "advocacy_campaigns",
             "links": {
-                "self": "http://localhost:3000/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04"
+                "self": "https://www.resistr.tech/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04"
             },
             "attributes": {
                 "title": "Prevent Military Action Against North Korea",
@@ -144,20 +144,20 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/relationships/user",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/user"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/relationships/user",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/user"
                     }
                 },
                 "targets": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/relationships/targets",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/targets"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/relationships/targets",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/targets"
                     }
                 },
                 "target_list": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/relationships/target_list",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/target_list"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/relationships/target_list",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/e895f3c4-d4f4-47fe-aeaa-1f4745287d04/target_list"
                     }
                 }
             }
@@ -166,7 +166,7 @@ JSON.parse(response.body)
             "id": "8a09df4c-cc63-47f8-a723-9f9b2886e83c",
             "type": "advocacy_campaigns",
             "links": {
-                "self": "http://localhost:3000/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c"
+                "self": "https://www.resistr.tech/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c"
             },
             "attributes": {
                 "title": "Support the College for All Act   ",
@@ -226,20 +226,20 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/relationships/user",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/user"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/relationships/user",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/user"
                     }
                 },
                 "targets": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/relationships/targets",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/targets"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/relationships/targets",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/targets"
                     }
                 },
                 "target_list": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/relationships/target_list",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/target_list"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/relationships/target_list",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/8a09df4c-cc63-47f8-a723-9f9b2886e83c/target_list"
                     }
                 }
             }
@@ -248,7 +248,7 @@ JSON.parse(response.body)
             "id": "884ebdeb-5980-465e-bfd5-c0011240230d",
             "type": "advocacy_campaigns",
             "links": {
-                "self": "http://localhost:3000/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d"
+                "self": "https://www.resistr.tech/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d"
             },
             "attributes": {
                 "title": "Protect Voting Rights with 2020 Census Funding",
@@ -267,20 +267,20 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/relationships/user",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/user"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/relationships/user",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/user"
                     }
                 },
                 "targets": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/relationships/targets",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/targets"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/relationships/targets",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/targets"
                     }
                 },
                 "target_list": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/relationships/target_list",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/target_list"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/relationships/target_list",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/884ebdeb-5980-465e-bfd5-c0011240230d/target_list"
                     }
                 }
             }
@@ -289,7 +289,7 @@ JSON.parse(response.body)
             "id": "6722e7a2-79e2-483e-b210-6a2ed68a79a1",
             "type": "advocacy_campaigns",
             "links": {
-                "self": "http://localhost:3000/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1"
+                "self": "https://www.resistr.tech/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1"
             },
             "attributes": {
                 "title": "Oppose the RAISE Act's Attack on Legal Immigration",
@@ -308,20 +308,20 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/relationships/user",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/user"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/relationships/user",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/user"
                     }
                 },
                 "targets": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/relationships/targets",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/targets"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/relationships/targets",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/targets"
                     }
                 },
                 "target_list": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/relationships/target_list",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/target_list"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/relationships/target_list",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/6722e7a2-79e2-483e-b210-6a2ed68a79a1/target_list"
                     }
                 }
             }
@@ -330,7 +330,7 @@ JSON.parse(response.body)
             "id": "32cd480a-0d71-446f-a4d1-3ebcb1cdbf30",
             "type": "advocacy_campaigns",
             "links": {
-                "self": "http://localhost:3000/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30"
+                "self": "https://www.resistr.tech/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30"
             },
             "attributes": {
                 "title": "Demand Fair Tax Reform ",
@@ -349,29 +349,29 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/relationships/user",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/user"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/relationships/user",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/user"
                     }
                 },
                 "targets": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/relationships/targets",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/targets"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/relationships/targets",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/targets"
                     }
                 },
                 "target_list": {
                     "links": {
-                        "self": "http://localhost:3000/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/relationships/target_list",
-                        "related": "http://localhost:3000/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/target_list"
+                        "self": "https://www.resistr.tech/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/relationships/target_list",
+                        "related": "https://www.resistr.tech/v1/advocacy_campaigns/32cd480a-0d71-446f-a4d1-3ebcb1cdbf30/target_list"
                     }
                 }
             }
         }
     ],
     "links": {
-        "first": "http://localhost:3000/v1/advocacy_campaigns?page%5Bnumber%5D=1&page%5Bsize%5D=10",
-        "next": "http://localhost:3000/v1/advocacy_campaigns?page%5Bnumber%5D=2&page%5Bsize%5D=10",
-        "last": "http://localhost:3000/v1/advocacy_campaigns?page%5Bnumber%5D=2&page%5Bsize%5D=10"
+        "first": "https://www.resistr.tech/v1/advocacy_campaigns?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+        "next": "https://www.resistr.tech/v1/advocacy_campaigns?page%5Bnumber%5D=2&page%5Bsize%5D=10",
+        "last": "https://www.resistr.tech/v1/advocacy_campaigns?page%5Bnumber%5D=2&page%5Bsize%5D=10"
     }
 }
 ```
@@ -380,7 +380,7 @@ This endpoint retrieves all advocacy campaigns.
 
 ### HTTP Request
 
-`GET http://localhost:3000/v1/advocacy_campaigns`
+`GET https://www.resistr.tech/v1/advocacy_campaigns`
 
 ### Filter
 
@@ -388,7 +388,7 @@ You can filter based on the following attributes
 
 Filter 		| Values | Description|  Example
 --------- |  ----------- |  ----------- |  -----------
-action_type | email, phone | action type for advocacy campaign  | http://localhost:3000/v1/advocacy_campaigns?filter[advocacy_campaign_type]=phone
+action_type | email, phone | action type for advocacy campaign  | https://www.resistr.tech/v1/advocacy_campaigns?filter[advocacy_campaign_type]=phone
 
 
 
@@ -396,7 +396,7 @@ action_type | email, phone | action type for advocacy campaign  | http://localho
 
 
 ```shell
-curl -X GET  "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86"
+curl -X GET  "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86"
   -H "Accept: application/vnd.api+json"
   -H "Content-Type: application/vnd.api+json"
 ```
@@ -418,7 +418,7 @@ JSON.parse(response.body)
         "id": "3c29ff31-d859-42fd-a786-c69306eadb86",
         "type": "advocacy_campaigns",
         "links": {
-            "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86"
+            "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86"
         },
         "attributes": {
             "title": "Express Outrage at Open White Supremacy Rally in Charlottesville",
@@ -437,20 +437,20 @@ JSON.parse(response.body)
         "relationships": {
             "user": {
                 "links": {
-                    "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/user",
-                    "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/user"
+                    "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/user",
+                    "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/user"
                 }
             },
             "targets": {
                 "links": {
-                    "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/targets",
-                    "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/targets"
+                    "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/targets",
+                    "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/targets"
                 }
             },
             "target_list": {
                 "links": {
-                    "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/target_list",
-                    "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/target_list"
+                    "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/target_list",
+                    "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/target_list"
                 }
             }
         }
@@ -462,7 +462,7 @@ This endpoint retrieves a specific advocacy campaign.
 
 ### HTTP Request
 
-`GET "http://localhost:3000/v1/advocacy_campaigns/<UUID>`
+`GET "https://www.resistr.tech/v1/advocacy_campaigns/<UUID>`
 
 ### URL Parameters
 
@@ -474,7 +474,7 @@ ID | The ID of the advocacy campaign to retrieve
 ## Create an Advocacy Campaign
 
 ```shell
-curl -X POST "http://localhost:3000/v1/advocacy_campaigns"
+curl -X POST "https://www.resistr.tech/v1/advocacy_campaigns"
   -H "Content-Type: application/vnd.api+json" 
   -H "Accept: application/vnd.api+json" 
   -H "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJleHAiOjE1MDI2NjMwMjEsInN1YiI6ImI0ZDQ5MDAzLWEyMWYtNGVjZi1hYjM3LTQzMmRkMWM4MzE4MiJ9.Q_QeKrpgvelRZ-XB8gM1B1SSrjeGVEK93HLW2p4SoFJv5zICQV6aFiKyA1lJ8qhrPBzqIPtTgqQBTN9ng0c0PA"
@@ -537,7 +537,7 @@ JSON.parse(response.body)
         "id": "3c29ff31-d859-42fd-a786-c69306eadb86",
         "type": "advocacy_campaigns",
         "links": {
-            "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86"
+            "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86"
         },
         "attributes": {
             "title": "Express Outrage at Open White Supremacy Rally in Charlottesville",
@@ -556,20 +556,20 @@ JSON.parse(response.body)
         "relationships": {
             "user": {
                 "links": {
-                    "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/user",
-                    "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/user"
+                    "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/user",
+                    "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/user"
                 }
             },
             "targets": {
                 "links": {
-                    "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/targets",
-                    "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/targets"
+                    "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/targets",
+                    "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/targets"
                 }
             },
             "target_list": {
                 "links": {
-                    "self": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/target_list",
-                    "related": "http://localhost:3000/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/target_list"
+                    "self": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/relationships/target_list",
+                    "related": "https://www.resistr.tech/v1/advocacy_campaigns/3c29ff31-d859-42fd-a786-c69306eadb86/target_list"
                 }
             }
         }
@@ -581,7 +581,7 @@ This endpoint creates a new advocacy campaign.
 
 ### HTTP Request
 
-`POST "http://localhost:3000/v1/advocacy_campaigns/"`
+`POST "https://www.resistr.tech/v1/advocacy_campaigns/"`
 
 Requests to create a resource must include a valid JWT token. This token can be obtained from the `authentication` endpoint.
 

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -16,7 +16,7 @@ The authentication flow for the cta-aggregator proceeds as follows:
 
 ```shell
 # Set the api key and secret in the authorization header
-curl -X POST "http://localhost:3000/v1/authentications"
+curl -X POST "https://www.resistr.tech/v1/authentications"
   -H "AUTHORIZATION: api-key:api-secret"
 ```
 
@@ -32,7 +32,7 @@ curl -X POST "http://localhost:3000/v1/authentications"
 
 ```shell
 # set the JWT in the authorization header
-curl -X POST "http://localhost:3000/some-protected-endpoint"
+curl -X POST "https://www.resistr.tech/some-protected-endpoint"
   -H "AUTHORIZATION: Bearer xxxx.yyyy"
 ```
 
@@ -56,7 +56,7 @@ You must replace <code>api-key</code> with your personal API key and <code>api-s
 ## Unsuccessful Authentication
 
 ```shell
-curl -X POST "http://localhost:3000/v1/authentications"
+curl -X POST "https://www.resistr.tech/v1/authentications"
   -H "AUTHORIZATION: wrong-api-key:or-secret"
 ```
 > The above command will return a 404 when the api key or secret is invalid
@@ -68,7 +68,7 @@ If the server cannot successfully validate that the key and secret belong to a r
 
 ```shell
 # set the JWT in the authorization header
-curl -X POST "http://localhost:3000/some-protected-endpoint"
+curl -X POST "https://www.resistr.tech/some-protected-endpoint"
   -H "AUTHORIZATION: Bearer xxxx.yyyy"
 ```
 > The above command will return a 401 when the JWT has expired
@@ -80,7 +80,7 @@ All JWTs issued by the server will expire after 24 hours. When a token expires, 
 
 ```shell
 # set a bad JWT in the authorization header
-curl -X POST "http://localhost:3000/some-protected-endpoint"
+curl -X POST "https://www.resistr.tech/some-protected-endpoint"
   -H "AUTHORIZATION: Bearer abcd.efgh"
 ```
 > The above command will return a 401 when the JWT is incorrect.

--- a/source/includes/_embedding.md
+++ b/source/includes/_embedding.md
@@ -24,7 +24,7 @@ req.onload=function(){
     response = JSON.parse(req.responseText);
     console.log(response);
 };
-req.open("GET",'http://localhost:3000/v1/events',true);
+req.open("GET",'https://www.resistr.tech/v1/events',true);
 req.send();
 ```
 
@@ -48,7 +48,7 @@ It's a bit easier to use the API with libraries like [jQuery](https://jquery.com
 > jQuery Version
 
 ```javascript
-$.get( "http://localhost:3000/v1/events", function( response ) {
+$.get( "https://www.resistr.tech/v1/events", function( response ) {
    console.log(response);
 });
 ```

--- a/source/includes/_events.md
+++ b/source/includes/_events.md
@@ -25,7 +25,7 @@ For more information on OSDI's Event resource, follow this link:
 ## Get All Future Events
 
 ```shell
-curl -X GET "http://localhost:3000/v1/events"
+curl -X GET "https://www.resistr.tech/v1/events"
   -H "Accept: application/vnd.api+json"
   -H "Content-Type: application/vnd.api+json"
 ```
@@ -47,7 +47,7 @@ JSON.parse(response.body)
             "id": "d9aa62d4-3d06-46d4-b855-d0a200b420ad",
             "type": "events",
             "links": {
-                "self": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad"
+                "self": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad"
             },
             "attributes": {
                 "title": "Join EMILY's List President Stephanie Schriock for a special reception in Santa Fe!",
@@ -66,14 +66,14 @@ JSON.parse(response.body)
             "relationships": {
                 "location": {
                     "links": {
-                        "self": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/relationships/location",
-                        "related": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/location"
+                        "self": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/relationships/location",
+                        "related": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/location"
                     }
                 },
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/relationships/user",
-                        "related": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/user"
+                        "self": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/relationships/user",
+                        "related": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/user"
                     }
                 }
             }
@@ -82,7 +82,7 @@ JSON.parse(response.body)
             "id": "3b511fd6-3057-46a0-9bac-e6c1633019ba",
             "type": "events",
             "links": {
-                "self": "http://localhost:3000/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba"
+                "self": "https://www.resistr.tech/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba"
             },
             "attributes": {
                 "title": "Join EMILY's List President Stephanie Schriock and featured speakers Senator Kirsten Gillibrand and Rep. Jacky Rosen at our Ignite Change Luncheon in New York!",
@@ -101,14 +101,14 @@ JSON.parse(response.body)
             "relationships": {
                 "location": {
                     "links": {
-                        "self": "http://localhost:3000/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba/relationships/location",
-                        "related": "http://localhost:3000/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba/location"
+                        "self": "https://www.resistr.tech/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba/relationships/location",
+                        "related": "https://www.resistr.tech/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba/location"
                     }
                 },
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba/relationships/user",
-                        "related": "http://localhost:3000/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba/user"
+                        "self": "https://www.resistr.tech/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba/relationships/user",
+                        "related": "https://www.resistr.tech/v1/events/3b511fd6-3057-46a0-9bac-e6c1633019ba/user"
                     }
                 }
             }
@@ -117,7 +117,7 @@ JSON.parse(response.body)
             "id": "b0e86149-c781-417e-a96f-1a57c3ed863b",
             "type": "events",
             "links": {
-                "self": "http://localhost:3000/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b"
+                "self": "https://www.resistr.tech/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b"
             },
             "attributes": {
                 "title": "Join EMILY's List President Stephanie Schriock and special guest Congresswoman Jacky Rosen at our 2017 Ignite Change Luncheon in San Francisco!",
@@ -136,22 +136,22 @@ JSON.parse(response.body)
             "relationships": {
                 "location": {
                     "links": {
-                        "self": "http://localhost:3000/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b/relationships/location",
-                        "related": "http://localhost:3000/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b/location"
+                        "self": "https://www.resistr.tech/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b/relationships/location",
+                        "related": "https://www.resistr.tech/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b/location"
                     }
                 },
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b/relationships/user",
-                        "related": "http://localhost:3000/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b/user"
+                        "self": "https://www.resistr.tech/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b/relationships/user",
+                        "related": "https://www.resistr.tech/v1/events/b0e86149-c781-417e-a96f-1a57c3ed863b/user"
                     }
                 }
             }
         }
     ],
     "links": {
-        "first": "http://localhost:3000/v1/events?page%5Bnumber%5D=1&page%5Bsize%5D=10",
-        "last": "http://localhost:3000/v1/events?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+        "first": "https://www.resistr.tech/v1/events?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+        "last": "https://www.resistr.tech/v1/events?page%5Bnumber%5D=1&page%5Bsize%5D=10"
     }
 }
 ```
@@ -160,7 +160,7 @@ This endpoint retrieves all future events.
 
 ### HTTP Request
 
-`GET http://localhost:3000/v1/events`
+`GET https://www.resistr.tech/v1/events`
 
 ### Filter
 
@@ -168,15 +168,15 @@ You can filter based on the following attribteus
 
 Filter    | Values      | Description                  | Example
 --------- | ----------- | -----------                  | -----------
-past      | true        | filter by events in the past | `GET "http://localhost:3000/v1/events?filter[past]=true"`
-free      | true, false | filter by free events        | `GET "http://localhost:3000/v1/events?filter[free]=true"`
+past      | true        | filter by events in the past | `GET "https://www.resistr.tech/v1/events?filter[past]=true"`
+free      | true, false | filter by free events        | `GET "https://www.resistr.tech/v1/events?filter[free]=true"`
 
 
 ## Get a Specific Event
 
 
 ```shell
-curl -X GET  "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad"
+curl -X GET  "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad"
   -H "Accept: application/vnd.api+json"
   -H "Content-Type: application/vnd.api+json"
 ```
@@ -198,7 +198,7 @@ JSON.parse(response.body)
         "id": "d9aa62d4-3d06-46d4-b855-d0a200b420ad",
         "type": "events",
         "links": {
-            "self": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad"
+            "self": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad"
         },
         "attributes": {
             "title": "Join EMILY's List President Stephanie Schriock for a special reception in Santa Fe!",
@@ -217,14 +217,14 @@ JSON.parse(response.body)
         "relationships": {
             "location": {
                 "links": {
-                    "self": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/relationships/location",
-                    "related": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/location"
+                    "self": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/relationships/location",
+                    "related": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/location"
                 }
             },
             "user": {
                 "links": {
-                    "self": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/relationships/user",
-                    "related": "http://localhost:3000/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/user"
+                    "self": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/relationships/user",
+                    "related": "https://www.resistr.tech/v1/events/d9aa62d4-3d06-46d4-b855-d0a200b420ad/user"
                 }
             }
         }
@@ -236,7 +236,7 @@ This endpoint retrieves a specific event.
 
 ### HTTP Request
 
-`GET "http://localhost:3000/v1/events/<UUID>`
+`GET "https://www.resistr.tech/v1/events/<UUID>`
 
 ### URL Parameters
 
@@ -248,7 +248,7 @@ ID        | The ID of the event to retrieve
 ## Create an Event
 
 ```shell
-curl -X POST "http://localhost:3000/v1/events"
+curl -X POST "https://www.resistr.tech/v1/events"
   -H "Content-Type: application/vnd.api+json"
   -H "Accept: application/vnd.api+json"
   -H "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJleHAiOjE1MDI2NjMwMjEsInN1YiI6ImI0ZDQ5MDAzLWEyMWYtNGVjZi1hYjM3LTQzMmRkMWM4MzE4MiJ9.Q_QeKrpgvelRZ-XB8gM1B1SSrjeGVEK93HLW2p4SoFJv5zICQV6aFiKyA1lJ8qhrPBzqIPtTgqQBTN9ng0c0PA"
@@ -305,7 +305,7 @@ CTAAggregatorClient::Event.create(event_attrs)
         "id": "6ef4013f-e016-4ca0-bb28-d2d3e39286d6",
         "type": "events",
         "links": {
-            "self": "http://localhost:3000/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6"
+            "self": "https://www.resistr.tech/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6"
         },
         "attributes": {
             "title": "Sit in at city hall",
@@ -321,14 +321,14 @@ CTAAggregatorClient::Event.create(event_attrs)
         "relationships": {
             "location": {
                 "links": {
-                    "self": "http://localhost:3000/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6/relationships/location",
-                    "related": "http://localhost:3000/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6/location"
+                    "self": "https://www.resistr.tech/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6/relationships/location",
+                    "related": "https://www.resistr.tech/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6/location"
                 }
             },
             "user": {
                 "links": {
-                    "self": "http://localhost:3000/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6/relationships/user",
-                    "related": "http://localhost:3000/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6/user"
+                    "self": "https://www.resistr.tech/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6/relationships/user",
+                    "related": "https://www.resistr.tech/v1/events/6ef4013f-e016-4ca0-bb28-d2d3e39286d6/user"
                 }
             }
         }
@@ -340,7 +340,7 @@ This endpoint creates a new event.
 
 ### HTTP Request
 
-`POST "http://localhost:3000/v1/events/"`
+`POST "https://www.resistr.tech/v1/events/"`
 
 Requests to create a resource must include a valid JWT token. This token can be obtained from the `authentication` endpoint.
 

--- a/source/includes/_locations.md
+++ b/source/includes/_locations.md
@@ -16,7 +16,7 @@ For more information on OSDI's Location resource, follow this link: [https://ope
 ## Get All Locations
 
 ```shell
-curl -X GET  "http://localhost:3000/v1/locations"
+curl -X GET  "https://www.resistr.tech/v1/locations"
   -H "Accept: application/vnd.api+json"
   -H "Content-Type: application/vnd.api+json"
 ```
@@ -38,7 +38,7 @@ JSON.parse(response.body)
             "id": "cf2e490a-7bed-46d5-8e0a-386dfb365cc8",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8"
+                "self": "https://www.resistr.tech/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8"
             },
             "attributes": {
                 "venue": null,
@@ -50,8 +50,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8/user"
+                        "self": "https://www.resistr.tech/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8/user"
                     }
                 }
             }
@@ -60,7 +60,7 @@ JSON.parse(response.body)
             "id": "dca1fc5b-a26b-4a7e-809a-26d8417921c8",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/dca1fc5b-a26b-4a7e-809a-26d8417921c8"
+                "self": "https://www.resistr.tech/v1/locations/dca1fc5b-a26b-4a7e-809a-26d8417921c8"
             },
             "attributes": {
                 "venue": null,
@@ -72,8 +72,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/dca1fc5b-a26b-4a7e-809a-26d8417921c8/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/dca1fc5b-a26b-4a7e-809a-26d8417921c8/user"
+                        "self": "https://www.resistr.tech/v1/locations/dca1fc5b-a26b-4a7e-809a-26d8417921c8/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/dca1fc5b-a26b-4a7e-809a-26d8417921c8/user"
                     }
                 }
             }
@@ -82,7 +82,7 @@ JSON.parse(response.body)
             "id": "2bd08fff-2154-4eaf-8a05-b014f462fa1e",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/2bd08fff-2154-4eaf-8a05-b014f462fa1e"
+                "self": "https://www.resistr.tech/v1/locations/2bd08fff-2154-4eaf-8a05-b014f462fa1e"
             },
             "attributes": {
                 "venue": null,
@@ -94,8 +94,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/2bd08fff-2154-4eaf-8a05-b014f462fa1e/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/2bd08fff-2154-4eaf-8a05-b014f462fa1e/user"
+                        "self": "https://www.resistr.tech/v1/locations/2bd08fff-2154-4eaf-8a05-b014f462fa1e/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/2bd08fff-2154-4eaf-8a05-b014f462fa1e/user"
                     }
                 }
             }
@@ -104,7 +104,7 @@ JSON.parse(response.body)
             "id": "58ad3adb-7cb5-4851-99e4-e9e3f7f6aee1",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/58ad3adb-7cb5-4851-99e4-e9e3f7f6aee1"
+                "self": "https://www.resistr.tech/v1/locations/58ad3adb-7cb5-4851-99e4-e9e3f7f6aee1"
             },
             "attributes": {
                 "venue": null,
@@ -116,8 +116,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/58ad3adb-7cb5-4851-99e4-e9e3f7f6aee1/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/58ad3adb-7cb5-4851-99e4-e9e3f7f6aee1/user"
+                        "self": "https://www.resistr.tech/v1/locations/58ad3adb-7cb5-4851-99e4-e9e3f7f6aee1/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/58ad3adb-7cb5-4851-99e4-e9e3f7f6aee1/user"
                     }
                 }
             }
@@ -126,7 +126,7 @@ JSON.parse(response.body)
             "id": "45edada9-947f-4c00-922f-9aaffe0f23a7",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/45edada9-947f-4c00-922f-9aaffe0f23a7"
+                "self": "https://www.resistr.tech/v1/locations/45edada9-947f-4c00-922f-9aaffe0f23a7"
             },
             "attributes": {
                 "venue": null,
@@ -138,8 +138,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/45edada9-947f-4c00-922f-9aaffe0f23a7/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/45edada9-947f-4c00-922f-9aaffe0f23a7/user"
+                        "self": "https://www.resistr.tech/v1/locations/45edada9-947f-4c00-922f-9aaffe0f23a7/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/45edada9-947f-4c00-922f-9aaffe0f23a7/user"
                     }
                 }
             }
@@ -148,7 +148,7 @@ JSON.parse(response.body)
             "id": "5539972b-9ea8-4c24-8718-4b9c3221a8c8",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/5539972b-9ea8-4c24-8718-4b9c3221a8c8"
+                "self": "https://www.resistr.tech/v1/locations/5539972b-9ea8-4c24-8718-4b9c3221a8c8"
             },
             "attributes": {
                 "venue": null,
@@ -160,8 +160,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/5539972b-9ea8-4c24-8718-4b9c3221a8c8/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/5539972b-9ea8-4c24-8718-4b9c3221a8c8/user"
+                        "self": "https://www.resistr.tech/v1/locations/5539972b-9ea8-4c24-8718-4b9c3221a8c8/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/5539972b-9ea8-4c24-8718-4b9c3221a8c8/user"
                     }
                 }
             }
@@ -170,7 +170,7 @@ JSON.parse(response.body)
             "id": "f2765cdc-c4c8-469d-bc2f-93533e655acd",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/f2765cdc-c4c8-469d-bc2f-93533e655acd"
+                "self": "https://www.resistr.tech/v1/locations/f2765cdc-c4c8-469d-bc2f-93533e655acd"
             },
             "attributes": {
                 "venue": null,
@@ -182,8 +182,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/f2765cdc-c4c8-469d-bc2f-93533e655acd/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/f2765cdc-c4c8-469d-bc2f-93533e655acd/user"
+                        "self": "https://www.resistr.tech/v1/locations/f2765cdc-c4c8-469d-bc2f-93533e655acd/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/f2765cdc-c4c8-469d-bc2f-93533e655acd/user"
                     }
                 }
             }
@@ -192,7 +192,7 @@ JSON.parse(response.body)
             "id": "954de3db-ef9e-4ed5-8809-d3fbd5bb168d",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/954de3db-ef9e-4ed5-8809-d3fbd5bb168d"
+                "self": "https://www.resistr.tech/v1/locations/954de3db-ef9e-4ed5-8809-d3fbd5bb168d"
             },
             "attributes": {
                 "venue": null,
@@ -204,8 +204,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/954de3db-ef9e-4ed5-8809-d3fbd5bb168d/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/954de3db-ef9e-4ed5-8809-d3fbd5bb168d/user"
+                        "self": "https://www.resistr.tech/v1/locations/954de3db-ef9e-4ed5-8809-d3fbd5bb168d/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/954de3db-ef9e-4ed5-8809-d3fbd5bb168d/user"
                     }
                 }
             }
@@ -214,7 +214,7 @@ JSON.parse(response.body)
             "id": "f050ccea-acfd-48d1-a7e2-792773e853a5",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/f050ccea-acfd-48d1-a7e2-792773e853a5"
+                "self": "https://www.resistr.tech/v1/locations/f050ccea-acfd-48d1-a7e2-792773e853a5"
             },
             "attributes": {
                 "venue": null,
@@ -226,8 +226,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/f050ccea-acfd-48d1-a7e2-792773e853a5/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/f050ccea-acfd-48d1-a7e2-792773e853a5/user"
+                        "self": "https://www.resistr.tech/v1/locations/f050ccea-acfd-48d1-a7e2-792773e853a5/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/f050ccea-acfd-48d1-a7e2-792773e853a5/user"
                     }
                 }
             }
@@ -236,7 +236,7 @@ JSON.parse(response.body)
             "id": "9c7b641b-2feb-48a3-b16c-4c1be029d440",
             "type": "locations",
             "links": {
-                "self": "http://localhost:3000/v1/locations/9c7b641b-2feb-48a3-b16c-4c1be029d440"
+                "self": "https://www.resistr.tech/v1/locations/9c7b641b-2feb-48a3-b16c-4c1be029d440"
             },
             "attributes": {
                 "venue": null,
@@ -248,17 +248,17 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/locations/9c7b641b-2feb-48a3-b16c-4c1be029d440/relationships/user",
-                        "related": "http://localhost:3000/v1/locations/9c7b641b-2feb-48a3-b16c-4c1be029d440/user"
+                        "self": "https://www.resistr.tech/v1/locations/9c7b641b-2feb-48a3-b16c-4c1be029d440/relationships/user",
+                        "related": "https://www.resistr.tech/v1/locations/9c7b641b-2feb-48a3-b16c-4c1be029d440/user"
                     }
                 }
             }
         }
     ],
     "links": {
-        "first": "http://localhost:3000/v1/locations?page%5Bnumber%5D=1&page%5Bsize%5D=10",
-        "next": "http://localhost:3000/v1/locations?page%5Bnumber%5D=2&page%5Bsize%5D=10",
-        "last": "http://localhost:3000/v1/locations?page%5Bnumber%5D=3&page%5Bsize%5D=10"
+        "first": "https://www.resistr.tech/v1/locations?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+        "next": "https://www.resistr.tech/v1/locations?page%5Bnumber%5D=2&page%5Bsize%5D=10",
+        "last": "https://www.resistr.tech/v1/locations?page%5Bnumber%5D=3&page%5Bsize%5D=10"
     }
 }
 ```
@@ -267,7 +267,7 @@ This endpoint retrieves all locations.
 
 ### HTTP Request
 
-`GET http://localhost:3000/v1/locations`
+`GET https://www.resistr.tech/v1/locations`
 
 ### Filter
 
@@ -275,16 +275,16 @@ You can filter based on the attributes below.
 
 Filter    | Example
 --------- |  -----------
-locality | `GET "http://localhost:3000/v1/locations?filter[locality]=Detroit"`
-region | `GET "http://localhost:3000/v1/locations?filter[region]=ID"`
-postal_code | `GET "http://localhost:3000/v1/locations?filter[postal_code]=66001"`
+locality | `GET "https://www.resistr.tech/v1/locations?filter[locality]=Detroit"`
+region | `GET "https://www.resistr.tech/v1/locations?filter[region]=ID"`
+postal_code | `GET "https://www.resistr.tech/v1/locations?filter[postal_code]=66001"`
 
 
 ## Get a Specific Location
 
 
 ```shell
-curl -X GET  "http://localhost:3000/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8"
+curl -X GET  "https://www.resistr.tech/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8"
   -H "Accept: application/vnd.api+json"
   -H "Content-Type: application/vnd.api+json"
 ```
@@ -306,7 +306,7 @@ The above command returns JSON structured like this:
         "id": "cf2e490a-7bed-46d5-8e0a-386dfb365cc8",
         "type": "locations",
         "links": {
-            "self": "http://localhost:3000/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8"
+            "self": "https://www.resistr.tech/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8"
         },
         "attributes": {
             "venue": "Riverfront park",
@@ -318,8 +318,8 @@ The above command returns JSON structured like this:
         "relationships": {
             "user": {
                 "links": {
-                    "self": "http://localhost:3000/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8/relationships/user",
-                    "related": "http://localhost:3000/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8/user"
+                    "self": "https://www.resistr.tech/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8/relationships/user",
+                    "related": "https://www.resistr.tech/v1/locations/cf2e490a-7bed-46d5-8e0a-386dfb365cc8/user"
                 }
             }
         }
@@ -332,7 +332,7 @@ This endpoint retrieves a specific Location.
 
 ### HTTP Request
 
-`GET "http://localhost:3000/v1/locations/<UUID>`
+`GET "https://www.resistr.tech/v1/locations/<UUID>`
 
 ### URL Parameters
 
@@ -344,7 +344,7 @@ ID | The ID of the location to retrieve
 ## Create a Location
 
 ```shell
-curl -X POST "http://localhost:3000/v1/locations"
+curl -X POST "https://www.resistr.tech/v1/locations"
   -H "Content-Type: application/vnd.api+json" 
   -H "Accept: application/vnd.api+json" 
   -H "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJleHAiOjE1MDI2NjMwMjEsInN1YiI6ImI0ZDQ5MDAzLWEyMWYtNGVjZi1hYjM3LTQzMmRkMWM4MzE4MiJ9.Q_QeKrpgvelRZ-XB8gM1B1SSrjeGVEK93HLW2p4SoFJv5zICQV6aFiKyA1lJ8qhrPBzqIPtTgqQBTN9ng0c0PA"
@@ -386,7 +386,7 @@ JSON.parse(response.body)
         "id": "a728f38a-623c-4342-aa89-7ab39fd83c35",
         "type": "locations",
         "links": {
-            "self": "http://localhost:3000/v1/locations/a728f38a-623c-4342-aa89-7ab39fd83c35"
+            "self": "https://www.resistr.tech/v1/locations/a728f38a-623c-4342-aa89-7ab39fd83c35"
         },
         "attributes": {
             "venue": "Moe's Cantina",
@@ -398,8 +398,8 @@ JSON.parse(response.body)
         "relationships": {
             "user": {
                 "links": {
-                    "self": "http://localhost:3000/v1/locations/a728f38a-623c-4342-aa89-7ab39fd83c35/relationships/user",
-                    "related": "http://localhost:3000/v1/locations/a728f38a-623c-4342-aa89-7ab39fd83c35/user"
+                    "self": "https://www.resistr.tech/v1/locations/a728f38a-623c-4342-aa89-7ab39fd83c35/relationships/user",
+                    "related": "https://www.resistr.tech/v1/locations/a728f38a-623c-4342-aa89-7ab39fd83c35/user"
                 }
             }
         }
@@ -411,6 +411,6 @@ This endpoint creates a Location.
 
 ### HTTP Request
 
-`POST "http://localhost:3000/v1/locations"`
+`POST "https://www.resistr.tech/v1/locations"`
 
 Requests to create a resource must include a valid JWT token. This token can be obtained from the `authentication` endpoint.

--- a/source/includes/_targets.md
+++ b/source/includes/_targets.md
@@ -22,7 +22,7 @@ For more information on OSDI's Target resource, follow this link: [https://opens
 ## Get All Targets
 
 ```shell
-curl -X GET "http://localhost:3000/v1/targets"
+curl -X GET "https://www.resistr.tech/v1/targets"
   -H "Accept: application/vnd.api+json"
   -H "Content-Type: application/vnd.api+json"
 ```
@@ -44,7 +44,7 @@ JSON.parse(response.body)
             "id": "360cda45-6d93-42ae-a0fb-e1f6ebdba564",
             "type": "targets",
             "links": {
-                "self": "http://localhost:3000/v1/targets/360cda45-6d93-42ae-a0fb-e1f6ebdba564"
+                "self": "https://www.resistr.tech/v1/targets/360cda45-6d93-42ae-a0fb-e1f6ebdba564"
             },
             "attributes": {
                 "organization": "Senate Committee on Health",
@@ -64,8 +64,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/targets/360cda45-6d93-42ae-a0fb-e1f6ebdba564/relationships/user",
-                        "related": "http://localhost:3000/v1/targets/360cda45-6d93-42ae-a0fb-e1f6ebdba564/user"
+                        "self": "https://www.resistr.tech/v1/targets/360cda45-6d93-42ae-a0fb-e1f6ebdba564/relationships/user",
+                        "related": "https://www.resistr.tech/v1/targets/360cda45-6d93-42ae-a0fb-e1f6ebdba564/user"
                     }
                 }
             }
@@ -74,7 +74,7 @@ JSON.parse(response.body)
             "id": "b92ff013-174d-4767-8892-645898cc5778",
             "type": "targets",
             "links": {
-                "self": "http://localhost:3000/v1/targets/b92ff013-174d-4767-8892-645898cc5778"
+                "self": "https://www.resistr.tech/v1/targets/b92ff013-174d-4767-8892-645898cc5778"
             },
             "attributes": {
                 "organization": "House Committee on Education and the Workforce",
@@ -94,8 +94,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/targets/b92ff013-174d-4767-8892-645898cc5778/relationships/user",
-                        "related": "http://localhost:3000/v1/targets/b92ff013-174d-4767-8892-645898cc5778/user"
+                        "self": "https://www.resistr.tech/v1/targets/b92ff013-174d-4767-8892-645898cc5778/relationships/user",
+                        "related": "https://www.resistr.tech/v1/targets/b92ff013-174d-4767-8892-645898cc5778/user"
                     }
                 }
             }
@@ -104,7 +104,7 @@ JSON.parse(response.body)
             "id": "3718fcd2-4317-4ed2-8548-bba7af7d5d2a",
             "type": "targets",
             "links": {
-                "self": "http://localhost:3000/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a"
+                "self": "https://www.resistr.tech/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a"
             },
             "attributes": {
                 "organization": " Department of Education",
@@ -124,8 +124,8 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a/relationships/user",
-                        "related": "http://localhost:3000/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a/user"
+                        "self": "https://www.resistr.tech/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a/relationships/user",
+                        "related": "https://www.resistr.tech/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a/user"
                     }
                 }
             }
@@ -134,7 +134,7 @@ JSON.parse(response.body)
             "id": "e696019e-f2d5-4097-b046-1a9efe2d2965",
             "type": "targets",
             "links": {
-                "self": "http://localhost:3000/v1/targets/e696019e-f2d5-4097-b046-1a9efe2d2965"
+                "self": "https://www.resistr.tech/v1/targets/e696019e-f2d5-4097-b046-1a9efe2d2965"
             },
             "attributes": {
                 "organization": "House Judiciary Committee",
@@ -154,16 +154,16 @@ JSON.parse(response.body)
             "relationships": {
                 "user": {
                     "links": {
-                        "self": "http://localhost:3000/v1/targets/e696019e-f2d5-4097-b046-1a9efe2d2965/relationships/user",
-                        "related": "http://localhost:3000/v1/targets/e696019e-f2d5-4097-b046-1a9efe2d2965/user"
+                        "self": "https://www.resistr.tech/v1/targets/e696019e-f2d5-4097-b046-1a9efe2d2965/relationships/user",
+                        "related": "https://www.resistr.tech/v1/targets/e696019e-f2d5-4097-b046-1a9efe2d2965/user"
                     }
                 }
             }
         }
     ],
     "links": {
-        "first": "http://localhost:3000/v1/targets?page%5Bnumber%5D=1&page%5Bsize%5D=10",
-        "last": "http://localhost:3000/v1/targets?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+        "first": "https://www.resistr.tech/v1/targets?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+        "last": "https://www.resistr.tech/v1/targets?page%5Bnumber%5D=1&page%5Bsize%5D=10"
     }
 }
 ```
@@ -172,13 +172,13 @@ This endpoint retrieves all targets.
 
 ### HTTP Request
 
-`GET http://localhost:3000/v1/targets`
+`GET https://www.resistr.tech/v1/targets`
 
 ## Get a Specific Target
 
 
 ```shell
-curl -X GET  "http://localhost:3000/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a",
+curl -X GET  "https://www.resistr.tech/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a",
   -H "Accept: application/vnd.api+json"
   -H "Content-Type: application/vnd.api+json"
 ```
@@ -199,7 +199,7 @@ JSON.parse(response.body)
         "id": "3718fcd2-4317-4ed2-8548-bba7af7d5d2a",
         "type": "targets",
         "links": {
-            "self": "http://localhost:3000/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a"
+            "self": "https://www.resistr.tech/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a"
         },
         "attributes": {
             "organization": " Department of Education",
@@ -219,8 +219,8 @@ JSON.parse(response.body)
         "relationships": {
             "user": {
                 "links": {
-                    "self": "http://localhost:3000/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a/relationships/user",
-                    "related": "http://localhost:3000/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a/user"
+                    "self": "https://www.resistr.tech/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a/relationships/user",
+                    "related": "https://www.resistr.tech/v1/targets/3718fcd2-4317-4ed2-8548-bba7af7d5d2a/user"
                 }
             }
         }
@@ -232,7 +232,7 @@ This endpoint retrieves a specific target.
 
 ### HTTP Request
 
-`GET "http://localhost:3000/v1/targets/<UUID>`
+`GET "https://www.resistr.tech/v1/targets/<UUID>`
 
 ### URL Parameters
 
@@ -245,7 +245,7 @@ ID | The ID of the targets to retrieve
 
 ```shell
 
-curl -X POST "http://localhost:3000/v1/targets"
+curl -X POST "https://www.resistr.tech/v1/targets"
   -H "Content-Type: application/vnd.api+json" 
   -H "Accept: application/vnd.api+json" 
   -H "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJleHAiOjE1MDI2NjMwMjEsInN1YiI6ImI0ZDQ5MDAzLWEyMWYtNGVjZi1hYjM3LTQzMmRkMWM4MzE4MiJ9.Q_QeKrpgvelRZ-XB8gM1B1SSrjeGVEK93HLW2p4SoFJv5zICQV6aFiKyA1lJ8qhrPBzqIPtTgqQBTN9ng0c0PA"
@@ -333,7 +333,7 @@ JSON.parse(response.body)
         "id": "9927bf38-dcaa-448c-acc7-4a4920466188",
         "type": "targets",
         "links": {
-            "self": "http://localhost:3000/v1/targets/9927bf38-dcaa-448c-acc7-4a4920466188"
+            "self": "https://www.resistr.tech/v1/targets/9927bf38-dcaa-448c-acc7-4a4920466188"
         },
         "attributes": {
             "organization": " Department of Education",
@@ -365,8 +365,8 @@ JSON.parse(response.body)
         "relationships": {
             "user": {
                 "links": {
-                    "self": "http://localhost:3000/v1/targets/9927bf38-dcaa-448c-acc7-4a4920466188/relationships/user",
-                    "related": "http://localhost:3000/v1/targets/9927bf38-dcaa-448c-acc7-4a4920466188/user"
+                    "self": "https://www.resistr.tech/v1/targets/9927bf38-dcaa-448c-acc7-4a4920466188/relationships/user",
+                    "related": "https://www.resistr.tech/v1/targets/9927bf38-dcaa-448c-acc7-4a4920466188/user"
                 }
             }
         }
@@ -378,6 +378,6 @@ This endpoint creates a new target.
 
 ### HTTP Request
 
-`POST "http://localhost:3000/v1/targets/"`
+`POST "https://www.resistr.tech/v1/targets/"`
 
 Requests to create a resource must include a valid JWT token. This token can be obtained from the `authentication` endpoint.

--- a/source/samples/jquery-bootstrap.html
+++ b/source/samples/jquery-bootstrap.html
@@ -39,7 +39,7 @@
         <script>
          $(function() {
              // Fetch all events from the API
-             $.get( "http://localhost:3000/v1/events", function( response ) {
+             $.get( "https://www.resistr.tech/v1/events", function( response ) {
                  $events = $('#events'); // Events div
                  $.each(response.data, function( index, event ) {
                      // Copy the template

--- a/source/samples/simple.html
+++ b/source/samples/simple.html
@@ -24,7 +24,7 @@
              });
          };
          // Connect to the API
-         req.open("GET",'http://localhost:3000/v1/events',true);
+         req.open("GET",'https://www.resistr.tech/v1/events',true);
          // and send the request.
          req.send();
         </script>


### PR DESCRIPTION
This PR addresses the following issue: https://github.com/RagtagOpen/cta-aggregator/issues/64.

The documentation site had previously been using "localhost" in the example code.  Now that the API is available under `resistr.tech`, the documentation site can now to use that domain when providing examples.

